### PR TITLE
Update README: added problem encountered during setup and workaround

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -4,9 +4,10 @@ Agile Web Development project created by Group 93
 Instructions to run Flask application
 1: create a python virtual environment (Only need to do this once)
 2: activate your virtual environment
-3: install requirements on your virtual environments
-4: initialise your local DB
-5: run the flask application
+3: upgrade pip to the latest version
+4: install requirements on your virtual environments
+5: initialise your local DB
+6: run the flask application
 
 
 
@@ -15,16 +16,32 @@ $ python -m venv venv
 
 2: Activate your virtual environment:
 $ source venv/bin/activate # macOS/Linux
-$ venv\scripts\acticate # Windows
+$ .\venv\Scripts\Activate.ps1 # Windows
 
-3: Install requirements on Venv (only need to do this once):
+If you encounter the following error on Windows:
+.\venv\Scripts\Activate.ps1 cannot be loaded because running scripts is disabled on this system.
+
+Please run PowerShell as Administrator (press Win + X → choose Windows PowerShell (Admin)), and enter the following command:
+$ set-executionpolicy remotesigned
+Then type Y and press Enter to confirm.
+
+To verify if the change was successful, run:
+$ get-executionpolicy
+If the output is 'RemoteSigned', the policy has been updated successfully.
+
+3. Upgrade pip to the latest version
+$ python.exe -m pip install --upgrade pip
+
+--- Before continuing, make sure your terminal is in the app directory (cd app) ---
+
+4: Install requirements on Venv (only need to do this once):
 $ pip install -r requirements.txt
 
 --- DATABASE ---
 
 There are three scripts to handle your local DB.
 
-4: Initialise the DB:
+5: Initialise the DB:
 $ python scripts/init_db.py
 
 Populate the DB for testing:


### PR DESCRIPTION
While following the steps in the original README file, I encountered several issues. After resolving them on my own, I updated and improved the README accordingly.

Here are the issues I faced and the solutions I implemented:

Issue 1:
In step 2: Activate your virtual environment, I’m using Windows. I was unable to run venv\scripts\acticate as written.
However, I found that running .\venv\Scripts\Activate.ps1 works and successfully activates the virtual environment.

Issue 2:
While activating the virtual environment, I encountered an error about script execution being disabled on Windows. This is due to the system’s execution policy. I added instructions in the README to guide users on how to modify the policy using PowerShell (Set-ExecutionPolicy) so that scripts can run properly.

Issue 3:
In Install requirements on Venv, I couldn’t run pip directly because my pip version was outdated.
I had to run python.exe -m pip install --upgrade pip to update it first. I added this step in the README before the pip installation to prevent confusion for others.

Issue 4:
Before running Install requirements on Venv and the DATABASE setup scripts, I needed to manually cd into the app directory (I was in the root directory initially).
This step was not mentioned in the README. I was unsure whether requirements.txt is meant to be in the root or app folder, but for now, I added a note in the README reminding users to cd into the app folder to avoid potential errors.