### PR TITLE
White text username in profile

### DIFF
--- a/app/templates/profile/_user_search.html
+++ b/app/templates/profile/_user_search.html
@@ -127,6 +127,7 @@
 
     .user-result-name {
         font-weight: 600;
+        color: black;
     }
 
     .add-friend-btn {


### PR DESCRIPTION
Made the searched user's username black on the profile page. (Was white before and couldnt see the username)
